### PR TITLE
Add dimmed background and transitions.

### DIFF
--- a/TLActionSheet.xcodeproj/project.pbxproj
+++ b/TLActionSheet.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CC13C2BA656B47822CBBFB90 /* TLDimmedPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13CBB092220B4940F2481C /* TLDimmedPresentationController.swift */; };
 		CC13C57F9BD3F91E44CBA935 /* TLActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13CB151621ECB3E2D40D5C /* TLActionController.swift */; };
+		CC13CD0ADED7DD3CC87401BA /* TLAlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13C3C8BEB376B6AED6B7FA /* TLAlertAction.swift */; };
 		CD5D4DA3252F0EAE00F109C6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5D4DA2252F0EAE00F109C6 /* AppDelegate.swift */; };
 		CD5D4DA7252F0EAE00F109C6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5D4DA6252F0EAE00F109C6 /* ViewController.swift */; };
 		CD5D4DAC252F0EAE00F109C6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CD5D4DAB252F0EAE00F109C6 /* Assets.xcassets */; };
@@ -34,7 +36,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CC13C3C8BEB376B6AED6B7FA /* TLAlertAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TLAlertAction.swift; sourceTree = "<group>"; };
 		CC13CB151621ECB3E2D40D5C /* TLActionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TLActionController.swift; sourceTree = "<group>"; };
+		CC13CBB092220B4940F2481C /* TLDimmedPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TLDimmedPresentationController.swift; sourceTree = "<group>"; };
 		CD5D4D9F252F0EAE00F109C6 /* TLActionSheet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TLActionSheet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD5D4DA2252F0EAE00F109C6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CD5D4DA6252F0EAE00F109C6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -103,6 +107,8 @@
 				CD5D4DAD252F0EAE00F109C6 /* LaunchScreen.storyboard */,
 				CD5D4DB0252F0EAE00F109C6 /* Info.plist */,
 				CC13CB151621ECB3E2D40D5C /* TLActionController.swift */,
+				CC13C3C8BEB376B6AED6B7FA /* TLAlertAction.swift */,
+				CC13CBB092220B4940F2481C /* TLDimmedPresentationController.swift */,
 			);
 			path = TLActionSheet;
 			sourceTree = "<group>";
@@ -257,6 +263,8 @@
 				CD5D4DA7252F0EAE00F109C6 /* ViewController.swift in Sources */,
 				CD5D4DA3252F0EAE00F109C6 /* AppDelegate.swift in Sources */,
 				CC13C57F9BD3F91E44CBA935 /* TLActionController.swift in Sources */,
+				CC13CD0ADED7DD3CC87401BA /* TLAlertAction.swift in Sources */,
+				CC13C2BA656B47822CBBFB90 /* TLDimmedPresentationController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TLActionSheet/TLActionController.swift
+++ b/TLActionSheet/TLActionController.swift
@@ -105,4 +105,13 @@ class TLActionController: UIViewController, UIViewControllerTransitioningDelegat
       actions.append(action)
     }
   }
+
+  internal func invokeCancelAction() {
+    guard let cancelAction = self.cancelAction else {
+      return
+    }
+
+    cancelAction.handler?(cancelAction)
+    self.dismiss(animated: true)
+  }
 }

--- a/TLActionSheet/TLActionController.swift
+++ b/TLActionSheet/TLActionController.swift
@@ -5,31 +5,6 @@
 import Foundation
 import UIKit
 
-public class TLAlertAction {
-  public enum Style: Int {
-    case `default` = 0
-
-    case cancel = 1
-
-    case destructive = 2
-  }
-
-  open var title: String?
-
-  open var isEnabled: Bool
-
-  fileprivate var style: Style
-
-  private var handler: ((UIAlertAction) -> Void)?
-
-  init(title: String?, style: TLAlertAction.Style, handler: ((UIAlertAction) -> Void)? = nil) {
-    self.title = title
-    self.handler = handler
-    self.style = style
-    isEnabled = true
-  }
-}
-
 private class TLActionView: UIView {
   private let label = UILabel()
 
@@ -52,59 +27,62 @@ private class TLActionView: UIView {
   }
 }
 
-class TLActionController: UIViewController {
+class TLActionController: UIViewController, UIViewControllerTransitioningDelegate {
 
   /* corner radius = 13 */
   /* item height 57 */
   /* 8 padding on sides */
-  private let stackView = UIStackView()
+
+  let stackViewContainer = UIView()
+
+  let stackView = UIStackView()
 
   private var actions: [TLAlertAction] = []
 
   private var cancelAction: TLAlertAction?
 
+  private var detailsTransitioningDelegate = TLDimmedModalTransitioningDelegate()
+
   init() {
     super.init(nibName: nil, bundle: nil)
 
-    self.modalPresentationStyle = .overFullScreen
+    self.modalPresentationStyle = .custom
+    self.transitioningDelegate = detailsTransitioningDelegate
+
     stackView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.axis = .vertical
+    stackView.distribution = .equalCentering
+    stackView.alignment = .bottom
+
+    stackViewContainer.translatesAutoresizingMaskIntoConstraints = false
+    stackViewContainer.layer.cornerRadius = 13
+    stackViewContainer.clipsToBounds = true
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+  override func loadView() {
+    super.loadView()
 
-    view.addSubview(stackView)
+    view.addSubview(stackViewContainer)
+    stackViewContainer.addSubview(stackView)
+
     view.superview?.backgroundColor = UIColor.black.withAlphaComponent(0.7)
-    stackView.axis = .vertical
-    stackView.distribution = .equalCentering
-    stackView.alignment = .bottom
-    stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-    stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-    stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-    stackView.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+
+    stackViewContainer.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 8).isActive = true
+    stackViewContainer.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -8).isActive = true
+    stackViewContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+    stackViewContainer.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+    stackViewContainer.backgroundColor = .orange
+
+    stackView.leadingAnchor.constraint(equalTo: stackViewContainer.leadingAnchor).isActive = true
+    stackView.trailingAnchor.constraint(equalTo: stackViewContainer.trailingAnchor).isActive = true
+    stackView.bottomAnchor.constraint(equalTo: stackViewContainer.bottomAnchor).isActive = true
+    stackView.topAnchor.constraint(equalTo: stackViewContainer.topAnchor).isActive = true
     buildActionViews()
   }
-
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-//    self.transitionCoordinator?.containerView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
-
-    guard let transitionCoordinator = self.transitionCoordinator else {
-      return
-    }
-
-    transitionCoordinator.containerView.wantsLae
-    transitionCoordinator.containerView.layer.backgroundColor = UIColor.red.cgColor
-  }
-
-//  override func viewDidAppear(_ animated: Bool) {
-//    super.viewDidAppear(animated)
-//    self.transitionCoordinator?.containerView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
-//  }
 
   private func buildActionViews() {
     for action in actions {

--- a/TLActionSheet/TLAlertAction.swift
+++ b/TLActionSheet/TLAlertAction.swift
@@ -20,9 +20,9 @@ public class TLAlertAction {
 
   var style: Style
 
-  private var handler: ((UIAlertAction) -> Void)?
+  internal var handler: ((TLAlertAction) -> Void)?
 
-  init(title: String?, style: TLAlertAction.Style, handler: ((UIAlertAction) -> Void)? = nil) {
+  init(title: String?, style: TLAlertAction.Style, handler: ((TLAlertAction) -> Void)? = nil) {
     self.title = title
     self.handler = handler
     self.style = style

--- a/TLActionSheet/TLAlertAction.swift
+++ b/TLActionSheet/TLAlertAction.swift
@@ -1,0 +1,31 @@
+//
+// Created by Terry Lewis on 9/10/20.
+//
+
+import Foundation
+import UIKit
+
+public class TLAlertAction {
+  public enum Style: Int {
+    case `default` = 0
+
+    case cancel = 1
+
+    case destructive = 2
+  }
+
+  open var title: String?
+
+  open var isEnabled: Bool
+
+  var style: Style
+
+  private var handler: ((UIAlertAction) -> Void)?
+
+  init(title: String?, style: TLAlertAction.Style, handler: ((UIAlertAction) -> Void)? = nil) {
+    self.title = title
+    self.handler = handler
+    self.style = style
+    isEnabled = true
+  }
+}

--- a/TLActionSheet/TLDimmedPresentationController.swift
+++ b/TLActionSheet/TLDimmedPresentationController.swift
@@ -1,0 +1,124 @@
+//
+// Created by Terry Lewis on 9/10/20.
+//
+
+import Foundation
+import UIKit
+
+private class TLDimmedPresentationController: UIPresentationController, UIViewControllerTransitioningDelegate {
+
+  private lazy var tapGestureRecognizer: UITapGestureRecognizer! = {
+    UITapGestureRecognizer(target: self, action: #selector(onTapDimView(sender:)))
+  }()
+
+  override func presentationTransitionWillBegin() {
+    guard let containerView = containerView,
+          let transitionCoordinator = presentingViewController.transitionCoordinator else {
+      return
+    }
+
+    if tapGestureRecognizer.view != containerView {
+      containerView.isUserInteractionEnabled = true
+      containerView.addGestureRecognizer(tapGestureRecognizer)
+    }
+
+    containerView.backgroundColor = .clear
+
+    transitionCoordinator.animate(alongsideTransition: { [weak self] context in
+      containerView.backgroundColor = UIColor.black.withAlphaComponent(0.48)
+    }, completion: nil)
+  }
+
+  override func dismissalTransitionWillBegin() {
+    guard let containerView = containerView,
+          let transitionCoordinator = presentingViewController.transitionCoordinator else {
+      return
+    }
+
+    transitionCoordinator.animate(alongsideTransition: { [weak self] context in
+      containerView.backgroundColor = .clear
+    }, completion: nil)
+  }
+
+  @objc func onTapDimView(sender: Any?) {
+    self.presentedViewController.dismiss(animated: true)
+  }
+}
+
+private class TLTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  let presenting: Bool
+
+  init(presenting: Bool) {
+    self.presenting = presenting
+
+    super.init()
+  }
+
+  func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+    0.3
+  }
+
+  func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    let toViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to)!
+    let fromViewController = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from)!
+    let containerView = transitionContext.containerView
+
+    let animationDuration = transitionDuration(using: transitionContext)
+
+    guard let actionController = presenting ? (toViewController as? TLActionController) : (
+        fromViewController as? TLActionController
+    ) else {
+      return
+    }
+
+    /* Trigger layout to obtain accurate size of stackViewContainer. */
+    actionController.view.setNeedsLayout()
+    actionController.view.layoutIfNeeded()
+
+
+    let offset = CGFloat(100)
+
+    if presenting {
+      toViewController.view.transform = CGAffineTransform(
+          translationX: 0,
+          y: actionController.stackViewContainer.frame.height + offset
+      )
+      containerView.addSubview(toViewController.view)
+    }
+
+    UIView.animate(withDuration: animationDuration, animations: {
+      if self.presenting {
+        toViewController.view.transform = CGAffineTransform.identity
+      } else {
+        fromViewController.view.transform = CGAffineTransform(
+            translationX: 0,
+            y: actionController.stackViewContainer.frame.height + offset
+        )
+      }
+    }, completion: { finished in
+      transitionContext.completeTransition(finished)
+    })
+  }
+}
+
+final class TLDimmedModalTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
+  func presentationController(
+      forPresented presented: UIViewController,
+      presenting: UIViewController?,
+      source: UIViewController
+  ) -> UIPresentationController? {
+    TLDimmedPresentationController(presentedViewController: presented, presenting: presenting)
+  }
+
+  func animationController(
+      forPresented presented: UIViewController,
+      presenting: UIViewController,
+      source: UIViewController
+  ) -> UIViewControllerAnimatedTransitioning? {
+    TLTransitionAnimator(presenting: true)
+  }
+
+  func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    TLTransitionAnimator(presenting: false)
+  }
+}

--- a/TLActionSheet/TLDimmedPresentationController.swift
+++ b/TLActionSheet/TLDimmedPresentationController.swift
@@ -41,7 +41,11 @@ private class TLDimmedPresentationController: UIPresentationController, UIViewCo
   }
 
   @objc func onTapDimView(sender: Any?) {
-    self.presentedViewController.dismiss(animated: true)
+    guard let actionController = presentedViewController as? TLActionController else {
+      return
+    }
+
+    actionController.invokeCancelAction()
   }
 }
 

--- a/TLActionSheet/ViewController.swift
+++ b/TLActionSheet/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    classicButton.setTitle("Open UIAlertController", for: .normal)
+    classicButton.setTitle("Present UIAlertController", for: .normal)
     classicButton.addTarget(self, action: #selector(openClassic(sender:)), for: .touchUpInside)
     view.addSubview(classicButton)
 
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
     classicButton.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
     classicButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
 
-    newButton.setTitle("New UIAlertController", for: .normal)
+    newButton.setTitle("Present TLAlertController", for: .normal)
     newButton.addTarget(self, action: #selector(openNew(sender:)), for: .touchUpInside)
     view.addSubview(newButton)
 


### PR DESCRIPTION
The default modal transition seems a bit too fast and has a strange timing curve, since the alert buttons are the bottom of the view controller. This PR offsets the view controller closely off the bottom of the screen, resulting in a smoother animation.

A dimming background view has been added which can be tapped to dismiss the view controller. The view can be tapped to invoke the cancel action, so long as a cancel action has been set on the alert controller.